### PR TITLE
Remove the error: The "string" plugin does not exist

### DIFF
--- a/src/Resources/skeleton/module/src/Entity/entity-content.php.twig
+++ b/src/Resources/skeleton/module/src/Entity/entity-content.php.twig
@@ -167,7 +167,7 @@ class {{ entity_class }} extends ContentEntityBase implements {{ entity_class }}
         'weight' => -4,
       ))
       ->setDisplayOptions('form', array(
-        'type' => 'string',
+        'type' => 'string_textfield',
         'weight' => -4,
       ))
       ->setDisplayConfigurable('form', TRUE)


### PR DESCRIPTION
After generate:entity:content, when I added new fields to the entity using the UI I get this error:

"There was a problem creating field NameOfTheField: The "string" plugin does not exist."

I have seen that in the node entity the type in the form is string_textfield and not string.
